### PR TITLE
Maintainer guidelines

### DIFF
--- a/maintaining.rst
+++ b/maintaining.rst
@@ -4,40 +4,75 @@ Maintaining collections
 
 .. contents:: Topics
 
+Collection maintainership
+=========================
+
 What is the collection maintenance
-==================================
+----------------------------------
 
-A community of any collection can be logically divided into three major groups:
+Ansible collections community can be logically divided into four major groups:
 
-  1. Maintainers (collection owners).
-  2. Contributors.
-  3. Users.
+  1. Steering committee members (make desicions in scope of all the collections included in Ansible package and related areas).
+  2. Maintainers (collection owners).
+  3. Contributors.
+  4. Users.
 
 Maintainers are people who are responsible for collection maintenance.
 
-The collection maintenance consists of the regular activities listed in this document.
+The collection maintenance consists of the regular activities listed in these guidelines.
 
-Maintainers can divide the activities between each other, for example, someone can be a release manager and someone can be responsible for the collection documentation.
-
-Besides that, collection maintainers are watching that their collections adhear the `Collection Requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_.
+In particular, collection maintainers do:
+  - :ref:`Review <Reviewing>` and :ref:`commit <Commiting>` changes made by other contributors.
+  - :ref:`Backport <Backporting>` changes to stable branches.
+  - Address issues discovered to appropriate contributors.
+  - :ref:`Release <Releasing>` collections.
+  - Watch that collections adhear the `Collection Requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_.
+  - Keep tracking changes announced in ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_ and timely update a collection in accordance with them.
 
 Who is a collection maintainer
-==============================
+------------------------------
 
-A collection maintainer is a contributor trusted by the community who makes significant and regular contributions to the project and showed themselves as a specialist in the related area and is able to manage the collection performing the tasks listed in this document.
+A collection maintainer is a contributor trusted by the community who makes significant and regular contributions to the project and showed themselves as a specialist in the related area.
 
-A collection maintainer has extended permissions in the collection scope. For details, refer to :ref:`_collection-maintainers`.
+Collection maintainers has :ref:`extended permissions <Collection maintainers>` in the collection scope.
+
+Collection maintainers satisfy the :ref:`requirements <Requirements for maintainers>`.
+
+Requirements for maintainers
+----------------------------
+
+Maintainers (including candidates) have:
+
+  - Acted in accordance with `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_.
+  - History of multiple contribution to a collection.
+  - Exellent technical judgement in collection-related areas.
+  - Responsiveness to mentions in issues and pull requests.
+  - Responsiveness to issues and pull requests assigned to them.
+  - Read these guidelines and the linked documents.
+  - Subscribed to:
+
+    + a collection repository (the ``Watch`` button => ``All activity``),
+    + the ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_,
+    + the `Bullhorn newsletter <https://github.com/ansible/community/issues/546>`_.
+  - Knowledge and intention to manage a collection performing the tasks listed in these guidelines. Maintainers can divided responsibilities between each other.
 
 How to become a maintainer
-==========================
+--------------------------
 
-[DRAFT] Describe how, basically:
+[DRAFT] May either self-nominate, be nominated by another maintainer...
+
+[TODO] Reference to the path here (should be created first).
+
+[DRAFT] The path is basically:
 
   1. Contribute
   2. Communicate
   3. Stay persistent
   4. Learn
   5. Submit an application (maybe an issue under https://github.com/ansible/community ?)
+  6. Become a maintainer
+  7. Participate in Ansible community IRC meetings discussing topics listed in.. Do not hesitate to share your thoughts - any opinions are much appreciated.
+  8. Become a steering committee member.
 
 Communication
 =============
@@ -49,10 +84,9 @@ Be informed
 
 Good communication is vital for prosperity of the project.
 
-Moreover, collection maintainers should be informed about important changes that impact all or many
-of the collections (for example, CI related) and act correspondingly to keep them up to date.
+Moreover, collection maintainers must be informed about important changes that impact all or many of the collections (for example, CI related) and act correspondingly to keep them up to date.
 
-It is highly recommended to subscribe to the "Changes impacting collection contributors and maintainers" `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_ and the `Bullhorn newsletter <https://github.com/ansible/community/issues/546>`_.
+It is required for collection maintainers to be subscribed to the ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_ and the `Bullhorn newsletter <https://github.com/ansible/community/issues/546>`_.
 
 Communication channels
 ----------------------
@@ -65,8 +99,8 @@ Collection contributors and maintainers communicate by:
     + use the link in this `issue <https://github.com/ansible/community/issues/546>`_ to subscribe to the newsletter
     + if you have something important to announce (for example, releases made recently), put a comment in the issue
   * IRC channels such as ``#ansible-community``, ``#ansible-devel``, and specific ones
-  * Mailing lists
-  * Collection pinboards, issues, and GitHub discussions in corresponding repositories
+  * mailing lists
+  * collection pinboards, issues, and GitHub discussions in corresponding repositories
   * quarterly contributor summits
   * Ansible fests and local meetups
 
@@ -86,9 +120,7 @@ Maintainers review and merge pull requests following
 the `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_,
 `Review checklist <review_checklist.rst>`_, and the `Committer guidelines <https://docs.ansible.com/ansible/devel/community/committer_guidelines.html>`_.
 
-There can be two kinds of maintainers: :ref:`_collection-maintainers` and :ref:`_module-maintainers`.
-
-.. _collection-maintainers:
+There can be two kinds of maintainers: :ref:`collection maintainers <Collection maintainers>` and :ref:`module maintainers <Module maintainers>`.
 
 Collection maintainers
 ----------------------
@@ -98,8 +130,6 @@ Collection-scope maintainers are contributors who have the ``write`` or higher a
 They have the commit right and can merge pull requests among other permissions.
 
 If applicable, the collection maintainers expand a pull of module maintainers.
-
-.. _module-maintainers:
 
 Module maintainers
 ------------------

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -45,6 +45,8 @@ Collection maintainers has :ref:`extended permissions<Collection maintainers>` i
 
 Collection maintainers satisfy the :ref:`requirements<Requirements for maintainers>`.
 
+.. _Requirements for maintainers:
+
 Requirements for maintainers
 ----------------------------
 
@@ -70,6 +72,8 @@ How to become a maintainer
 A person who is interested in becoming a maintainer and satisfies the :ref:`requirements<Requirements for maintainers>` may either self-nominate or be nominated by another maintainer.
 
 To nominate a candidate, create and issue under the `ansible/community <https://github.com/ansible/community>`_ repository.
+
+.. _Communication:
 
 Communication
 =============
@@ -110,6 +114,8 @@ The important project-scale decisions are made by the community and the streetin
 
 If you want to see what is on the agenda, refer to the issues in the `community-topics repository <https://github.com/ansible-community/community-topics>`_. If you want to submit a topic, create an issue in the repository.
 
+.. _Committing:
+
 Committing
 ==========
 
@@ -119,6 +125,8 @@ There can be two kinds of maintainers: :ref:`collection maintainers<Collection m
 
 For the both kinds it is worth keeping in mind that “with great power comes great responsibility”.
 
+.. _Collection maintainers:
+
 Collection maintainers
 ----------------------
 
@@ -127,6 +135,8 @@ Collection-scope maintainers are contributors who have the ``write`` or higher a
 They have the commit right and can merge pull requests among other permissions.
 
 If applicable, the collection maintainers expand a pull of module maintainers.
+
+.. _Module maintainers:
 
 Module maintainers
 ------------------
@@ -158,6 +168,8 @@ they can offer the author to become a module maintainer, in other words, to add 
 
 Module maintainers, as well as collection ones, act in accordance to the `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_, the `Review checklist <review_checklist.rst>`_, and the `Committer guidelines <https://docs.ansible.com/ansible/devel/community/committer_guidelines.html>`_.
 
+.. _Backporting:
+
 Backporting
 ===========
 
@@ -167,6 +179,8 @@ following the `semantic versioning <https://semver.org/>`_ and release policies 
 For more information about the process, refer to the `Backporting guidelines <https://docs.ansible.com/ansible/devel/community/development_process.html#backporting-merged-prs-in-ansible-core>`_.
 
 For convenience, backporting can be implemented automatically using GitHub bots (for example, with the `Patchback app <https://github.com/apps/patchback>`_) and labeling like it is done in `community.general <https://github.com/ansible-collections/community.general>`_ and `community.network <https://github.com/ansible-collections/community.network>`_.
+
+.. _Releasing:
 
 Releasing
 =========
@@ -183,6 +197,8 @@ Generally, releasing in the collections consists of:
   5. Final announcement.
 
 For more information about the process, refer to the `Releasing guidelines <releasing.rst>`_.
+
+.. _Expanding community:
 
 Expanding community
 ===================
@@ -221,6 +237,8 @@ Promote active contributors satisfying :ref:`requirements<Requirements for maint
 
 Create the ``MAINTAINERS`` file and keep it updated.
 
+.. _Checklist:
+
 Checklist
 ---------
 
@@ -245,6 +263,8 @@ Documentation
 Maintainers look after the collection documentation.
 
 In particular, they are watching that documents of the collection scope, like ``README.md``, are relevant and timely updated and that modules / plugins documentation adhears the `Ansible documentation format <https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html>`_ and the `Style guide <https://docs.ansible.com/ansible/devel/dev_guide/style_guide/index.html#style-guide>`_.
+
+.. _Reviewing:
 
 Reviewing
 =========

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -4,22 +4,40 @@ Maintaining collections
 
 .. contents:: Topics
 
-What is maintenance and what it includes?
+What is the collection maintenance
+==================================
 
-  * point 1 (ref to the paragraph)
-  * point 2 (ref to the paragraph)
-  * point 3 (ref to the paragraph)
+A collection is an Open Source project.
+
+If a community of any Open Source project can be logically divided into three groups: core members, contributors, and users, the collection maintainers are the core members of the collection.
+
+The collection maintenance consists of the regular activities listed in this document.
+
+Maintainers can divide the activities between each other, for example, someone can be a release manager and someone can be responsible for the collection documentation.
+
+Besides that, collection maintainers are watching that their collections adhear the `Collection Requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_.
+
+Who is a collection maintainer
+==============================
+
+A collection maintainer is a contributor trusted by the community who made significant and regular contributions to the project and showed themselves as a specialist in the related area and is able to manage the collection performing the tasks listed in this document.
+
+A collection maintainer has extended permissions in the collection scope. For details, refer to :ref:`_collection-maintainers`.
 
 How to become a maintainer
 ==========================
 
-Describe how
+[DRAFT] Describe how, basically:
+1. Contribute
+2. Communicate
+3. Stay persistent
+4. Learn
+5. Submit an application (maybe an issue under https://github.com/ansible/community ?)
 
 Communication
 =============
 
-We follow the `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_
-in all interactions within the project.
+We follow the `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_ in all interactions within the project.
 
 Be informed
 -----------
@@ -52,7 +70,9 @@ For more information about available IRC channels and mailing lists, refer to th
 Weekly community IRC meetings
 -----------------------------
 
-The important project-scale decisions are made by the community and the streeting committee at weekly IRC meetings in the ``#ansible-community`` IRC channel. If you want to see what is on the agenda, refer to issues in the `community-topics repository <https://github.com/ansible-community/community-topics>`_. If you want to submit a topic, create an issue there.
+The important project-scale decisions are made by the community and the streeting committee at weekly IRC meetings in the ``#ansible-community`` IRC channel. See the `meeting schedule <>https://github.com/ansible/community/blob/main/meetings/README.md#schedule>`_.
+
+If you want to see what is on the agenda, refer to issues in the `community-topics repository <https://github.com/ansible-community/community-topics>`_. If you want to submit a topic, create an issue there.
 
 Committing
 ==========
@@ -110,46 +130,66 @@ Module maintainers, as well as collection ones, act in accordance to the `Ansibl
 Backporting
 ===========
 
-Explain, add a ref after writing a guide
+Collection maintainers backport merged pull requests to stable branches
+following the `semantic versioning <https://semver.org/>`_ and release policies of the collections.
 
-Nuances in c.g. / c.n
+For more information about the process, refer to the `Backporting guidelines <https://docs.ansible.com/ansible/devel/community/development_process.html#backporting-merged-prs-in-ansible-core>`_.
+
+Backporting can be implemented automatically using GitHub bots (for example, with the `Patchback app <https://github.com/apps/patchback>`_) and labeling like it is done in `community.general <https://github.com/ansible-collections/community.general>`_ and `community.network <https://github.com/ansible-collections/community.network>`_.
 
 Releasing
 =========
 
-(ref to releasing guidelines when merged)
+Collection maintainers release all supported stable versions of the collections regularly,
+provided that there have been enough changes to release.
+
+Generally, releasing in the collections consists of:
+1. Planning and announcement.
+2. Generating a changelog.
+3. Creating a release git tag and pushing it.
+4. Automatic publishing the release tarball on `Ansible Galaxy <https://galaxy.ansible.com/>`_ by Zuul.
+5. Final announcement.
+
+For more information about the process, refer to the `Releasing guidelines <releasing.rst>`_.
 
 Expanding contributors pool
 ===========================
 
-Ways to expand a contributors pool:
-
+[Draft] Ways to expand a contributors pool:
   * Looking for potential maintainer among current active contributors
   * Announcements
-  * ...
+  * Training
+
+Documentation
+=============
+
+Maintainers look after the collection documentation.
+
+In particular, they are watching that documents of the collection scope, like ``README.md``, are relevant and timely updated and that modules / plugins documentation adhears the `Ansible documentation format <https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html>`_ and the `Style guide <https://docs.ansible.com/ansible/devel/dev_guide/style_guide/index.html#style-guide>`_.
 
 Reviewing
 =========
 
-What:
-
-  * issues
+[Draft] What:
+  * issues (including bug report analysis, proposal analysis)
 
     - review issues yourself first (use the review guide) as they can request
       breaking changes, non-idempotent modules, etc
     - ask if the author wants to implement / solve the issue themselves
     - point to the quick start guide offering the author / other contributors
       to implement / solve the issue
-  * PRs
+  * PRs (proposal analysis)
 
     - first review quickly patches yourself if they don't contain breaking changes, etc.
     - first response is important, mention maintainers / authors / people
       who already contributed to the code
 
+They can accept or reject the proposed features / code changes
+
 Solving
 =======
 
-What:
+[Draft] What:
 
   * issues (contributing guidelines when merged)
   * abandoned PRs (ask their author about difficulties, offer help, etc.)

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -223,7 +223,7 @@ Thank all participants after merging or closing a proposal.
 
 Be responsive. Respond as quickly as possible. Even if you cannot review a proposal right now, greet and thank the author.
 
-Add and keep updated the ``CONTRIBUTORS`` file listing all the contributors including issue reporters and refer to it from your ``README``.
+If your collection is not huge, add and keep updated the ``CONTRIBUTORS`` file listing all the contributors including issue reporters and refer to it from your ``README``. You can ask contributors to do it themselves or add a note about this to the development documentation of the collection.
 
 Do not fix trivial non-critical bugs yourself. Instead, mentor a person who would like to contribute.
 Mark issues with labels like ``easy_fix``, ``help_wanted``, and ``documentation``.

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -210,7 +210,7 @@ Increasing a number of active contributors and maintainers
 
 Maintainers are interested in increasing a number of active long-term contributors for a collection they maintain.
 
-Contributors are reviewers, issue or pull request authors, testers, maintainer, and all other people who help develop the project.
+Contributors are reviewers, issue or pull request authors, testers, maintainers, and all other people who help develop the project.
 
 Every regular contributor once was a newcomer. Make the first experience as positive as possible to make the new people coming back.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -73,7 +73,7 @@ How to become a maintainer
 
 A person who is interested in becoming a maintainer and satisfies the :ref:`requirements<Requirements for maintainers>` may either self-nominate or be nominated by another maintainer.
 
-To nominate a candidate, create and issue under the `ansible/community <https://github.com/ansible/community>`_ repository.
+To nominate a candidate, please create a GitHub issue in the relevant collection repository repository.
 
 .. _Communication:
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -226,7 +226,7 @@ Be responsive. Respond as quickly as possible. Even if you cannot review a propo
 If your collection is not huge, add and keep updated the ``CONTRIBUTORS`` file listing all the contributors including issue reporters and refer to it from your ``README``. You can ask contributors to do it themselves or add a note about this to the development documentation of the collection.
 
 Do not fix trivial non-critical bugs yourself. Instead, mentor a person who would like to contribute.
-Mark issues with labels like ``easy_fix``, ``waiting_on_contributor``, and ``documentation``.
+Mark issues with labels like ``easy_fix``, ``waiting_on_contributor``, ``help_wanted``, and ``documentation``.
 They will let newcomers know where they can find easy wins.
 
 When reviewing an issue, if applicable, ask the author whether they want to fix the issue themselves providing the link to the `Quick-start guide <create_pr_quick_start_guide.rst>`.

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -43,7 +43,7 @@ Who is a collection maintainer
 
 A collection maintainer is a contributor trusted by the community who makes significant and regular contributions to the project and showed themselves as a specialist in the related area.
 
-Collection maintainers has :ref:`extended permissions<Collection maintainers>` in the collection scope.
+Collection maintainers have :ref:`extended permissions<Collection maintainers>` in the collection scope.
 
 Collection maintainers satisfy the :ref:`requirements<Requirements for maintainers>`.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -20,7 +20,7 @@ Besides that, collection maintainers are watching that their collections adhear 
 Who is a collection maintainer
 ==============================
 
-A collection maintainer is a contributor trusted by the community who made significant and regular contributions to the project and showed themselves as a specialist in the related area and is able to manage the collection performing the tasks listed in this document.
+A collection maintainer is a contributor trusted by the community who makes significant and regular contributions to the project and showed themselves as a specialist in the related area and is able to manage the collection performing the tasks listed in this document.
 
 A collection maintainer has extended permissions in the collection scope. For details, refer to :ref:`_collection-maintainers`.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -29,10 +29,10 @@ The collection maintenance consists of the regular activities listed in these gu
 
 In particular, collection maintainers:
 
-  - :ref:`review <Reviewing>` and :ref:`commit <Committing>` changes made by other contributors,
-  - :ref:`backport <Backporting>` changes to stable branches,
+  - :ref:`review<Reviewing>` and :ref:`commit<Committing>` changes made by other contributors,
+  - :ref:`backport<Backporting>` changes to stable branches,
   - address issues discovered to appropriate contributors,
-  - :ref:`release <Releasing>` collections,
+  - :ref:`release<Releasing>` collections,
   - watch that collections adhear the `Collection Requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_,
   - keep tracking changes announced in ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_ and timely update a collection in accordance with them.
 
@@ -41,9 +41,9 @@ Who is a collection maintainer
 
 A collection maintainer is a contributor trusted by the community who makes significant and regular contributions to the project and showed themselves as a specialist in the related area.
 
-Collection maintainers has :ref:`extended permissions <Collection maintainers>` in the collection scope.
+Collection maintainers has :ref:`extended permissions<Collection maintainers>` in the collection scope.
 
-Collection maintainers satisfy the :ref:`requirements <Requirements for maintainers>`.
+Collection maintainers satisfy the :ref:`requirements<Requirements for maintainers>`.
 
 Requirements for maintainers
 ----------------------------
@@ -67,7 +67,7 @@ Maintainers (including candidates) have:
 How to become a maintainer
 --------------------------
 
-A person who is interested in becoming a maintainer and satisfies the :ref:`requirements <Requirements for maintainers>` may either self-nominate or be nominated by another maintainer.
+A person who is interested in becoming a maintainer and satisfies the :ref:`requirements<Requirements for maintainers>` may either self-nominate or be nominated by another maintainer.
 
 To nominate a candidate, create and issue under the `ansible/community <https://github.com/ansible/community>`_ repository.
 
@@ -115,7 +115,7 @@ Committing
 
 Maintainers review and merge pull requests following the `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_, `Review checklist <review_checklist.rst>`_, and the `Committer guidelines <https://docs.ansible.com/ansible/devel/community/committer_guidelines.html#general-rules>`_.
 
-There can be two kinds of maintainers: :ref:`collection maintainers <Collection maintainers>` and :ref:`module maintainers <Module maintainers>`.
+There can be two kinds of maintainers: :ref:`collection maintainers<Collection maintainers>` and :ref:`module maintainers<Module maintainers>`.
 
 For the both kinds it is worth keeping in mind that “with great power comes great responsibility”.
 
@@ -217,7 +217,7 @@ Adopt a zero-tolerance policy towards behavior violating `Ansible Code of Conduc
 
 Announce that the project needs new contributors and maintainers through available communication channels.
 
-Promote active contributors satisfying :ref:`requirements <Requirements for maintainers>` to maintainers. Revise contributors activity regularly.
+Promote active contributors satisfying :ref:`requirements<Requirements for maintainers>` to maintainers. Revise contributors activity regularly.
 
 Create the ``MAINTAINERS`` file and keep it updated.
 
@@ -251,4 +251,4 @@ Reviewing
 
 Maintainers can accept or reject proposed changes.
 
-Maintainers review code proposals as well as reported issues following the `review checklist <review_checklist.rst>`_ in applicable parts and the recommendations mentioned in the :ref:`Expanding community <Expanding community>` paragraph.
+Maintainers review code proposals as well as reported issues following the `review checklist <review_checklist.rst>`_ in applicable parts and the recommendations mentioned in the :ref:`Expanding community<Expanding community>` paragraph.

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -63,7 +63,7 @@ Maintainers (including candidates) have:
   - Read these guidelines and the linked documents.
   - Subscribed to:
 
-    + a collection repository (the ``Watch`` button → ``All activity``),
+    + the collection repository (the ``Watch`` button → ``All activity``),
     + the ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_,
     + the `Bullhorn newsletter <https://github.com/ansible/community/issues/546>`_.
   - Knowledge and intention to manage a collection performing the tasks listed in these guidelines. Maintainers can divide responsibilities between each other.

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -64,7 +64,7 @@ Maintainers (including candidates) have:
   - Subscribed to:
 
     + the collection repository they maintain (the ``Watch`` button → ``All activity``),
-    + the ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_,
+    + the `"Changes impacting collection contributors and maintainers" GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_,
     + the `Bullhorn newsletter <https://github.com/ansible/community/issues/546>`_.
   - Knowledge and intention to manage a collection performing the tasks listed in these guidelines. Maintainers can divide responsibilities between each other.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -166,7 +166,7 @@ refer to the `Collection bot overview <https://github.com/ansible-community/coll
 
 When a collection maintainer considers a contribution to a file significant enough
 (it can be, for example, fixing a complex bug, adding a feature, providing regular reviews, and so on),
-they can offer the author to become a module maintainer, in other words, to add their GitHub login to ``.github/BOTMETA.yml``.
+they can offer the author to become a module maintainer, in other words, to add their GitHub account to ``.github/BOTMETA.yml``.
 
 Module maintainers, as well as collection ones, act in accordance to the `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_, the `Review checklist <review_checklist.rst>`_, and the `Committer guidelines <https://docs.ansible.com/ansible/devel/community/committer_guidelines.html>`_.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -212,7 +212,7 @@ Maintainers are interested in increasing a number of active long-term contributo
 
 Contributors are reviewers, issue or pull request authors, testers, maintainers, and all other people who help develop the project.
 
-Every regular contributor once was a newcomer. Make the first experience as positive as possible to make the new people coming back.
+Every regular contributor once was a newcomer. Make the first experience as positive as possible to encourage the new people coming back.
 
 Good development documentation makes contributors life much easier. Get feedback from new contributors if there were things they struggled with when working on their proposals and improve the documentation correspondingly.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -46,36 +46,43 @@ Ways:
 Committing
 ==========
 
-Maintainers merge pull requests following the `Review checklist <review_checklist.rst>`_ and
-the `Committer guidelines <https://docs.ansible.com/ansible/devel/community/committer_guidelines.html>`_.
+Maintainers review and merge pull requests following
+the `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_,
+`Review checklist <review_checklist.rst>`_, and the `Committer guidelines <https://docs.ansible.com/ansible/devel/community/committer_guidelines.html>`_.
 
-There can be two kinds of maintainers: collection-scope maintainers and module-scope maintainers.
+There can be two kinds of maintainers: :ref:`_collection-maintainers` and :ref:`_module-maintainers`.
 
-Collection-scope maintainers
-----------------------------
+.. _collection-maintainers:
+
+Collection maintainers
+----------------------
 
 Collection-scope maintainers are contributors who have the ``write`` or higher access level in a collection.
 
 They have the commit right and can merge pull requests among other permissions.
 
-If applicable, the collection-scope maintainers expand a pull of module-scope maintainers.
+If applicable, the collection maintainers expand a pull of module maintainers.
 
-Module-scope maintainers
-------------------------
+.. _module-maintainers:
 
-This kind of maintainers exists in collections that have the `collection bot <https://github.com/ansible-community/collection_bot>`_,
+Module maintainers
+------------------
+
+Module-scope maintainers exist in collections that have the `collection bot <https://github.com/ansible-community/collection_bot>`_,
 for example `community.general <https://github.com/ansible-collections/community.general>`_
 and `community.network <https://github.com/ansible-collections/community.network>`_.
 
-Module-scope maintainers are contributors who are listed in ``.github/BOTMETA.yml``.
+Being a module maintainer is the stage prior to becoming a collection maintainer.
 
-The scope can be a file (for example, a module or plugin), directory, or repository.
+Module maintainers are contributors who are listed in ``.github/BOTMETA.yml``.
 
-Because in most cases the scope is a module or group of modules, we call these contributors module-scope maintainers.
+The scope can be any file (for example, a module or plugin), directory, or repository.
 
-The collection bot notifies module-scope maintainers when issues / pull requests related to files they maintain are created.
+Because in most cases the scope is a module or group of modules, we call these contributors module maintainers.
 
-Module-scope maintainers have the indirect commit right implemented through
+The collection bot notifies module maintainers when issues / pull requests related to files they maintain are created.
+
+Module maintainers have the indirect commit right implemented through
 the `collection bot <https://github.com/ansible-community/collection_bot>`_.
 When two module maintainers comment with the keywords ``shipit``, ``LGTM``, or ``+1`` a pull request
 which changes a module they maintain, the collection bot will merge the pull request automatically.
@@ -83,37 +90,11 @@ which changes a module they maintain, the collection bot will merge the pull req
 For more information about the collection bot and its interface,
 refer to the `Collection bot overview <https://github.com/ansible-community/collection_bot/blob/main/ISSUE_HELP.md>`_.
 
-When a collection-scope maintainer considers a contribution to a file significant enough
+When a collection maintainer considers a contribution to a file significant enough
 (it can be, for example, fixing a complex bug, adding a feature, providing regular reviews, and so on),
-they can offer the author to become a maintainer, in other words to add their GitHub login to ``.github/BOTMETA.yml``.
+they can offer the author to become a module maintainer, in other words to add their GitHub login to ``.github/BOTMETA.yml``.
 
-The wording of the offer can be::
-
-  Thank you @... for the contribution!
-
-  Would you like to be added to a corresponding team in `.github/BOTMETA.yml` as a maintainer of the module?
-
-  We have a bot in this collection which is tracking the issues/pull requests including for keywords
-  such as `shipit`; the full list is [here](https://github.com/ansible-community/collection_bot/blob/main/ISSUE_HELP.md).
-
-  If your GitHub login is listed in `.github/BOTMETA.yml` as a maintainer of a module and
-  you'll put `shipit`, `LGTM`, or `+1` in a pull request that touches the module, the bot will count your `shipit`.
-  If another maintainer also puts `shipit` (so we need two), the pull request will be merged by the bot automatically.
-  So being a maintainer in `github/BOTMETA.yml` is the indirect commit privilege.
-
-  The bot also notifies module maintainers when related issues and pull requests are created.
-
-  Module-scope maintainers who are active and provide regular significant contributions (reviews and code contributions)
-  in a collection scope can be granted the `write` access to the repository.
-  In other words, they become collection-scope maintainers and can merge others' pull requests, release the collection, and so on.
-
-  We have the [review checklist](https://github.com/ansible/community-docs/blob/main/review_checklist.rst) and
-  the [contributing guidelines](https://github.com/ansible/community-docs/blob/main/contributing.rst)
-  to help maintainers on their journey.
-
-  What do you think?
-
-  Thank you!
+Module maintainers, as well as collection ones, act in accordance to the `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_, the `Review checklist <review_checklist.rst>`_, and the `Committer guidelines <https://docs.ansible.com/ansible/devel/community/committer_guidelines.html>`_.
 
 Backporting
 ===========
@@ -122,7 +103,6 @@ Explain, add a ref after writing a guide
 
 Nuances in c.g. / c.n
 
-=========
 Releasing
 =========
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -156,7 +156,7 @@ Because in most cases the scope is a module or group of modules, we call these c
 
 The collection bot notifies module maintainers when issues / pull requests related to files they maintain are created.
 
-Module maintainers have the indirect commit right implemented through the `collection bot <https://github.com/ansible-community/collection_bot>`_.
+Module maintainers have indirect commit rights implemented through the `collection bot <https://github.com/ansible-community/collection_bot>`_.
 When two module maintainers comment with the keywords ``shipit``, ``LGTM``, or ``+1`` a pull request
 which changes a module they maintain, the collection bot will merge the pull request automatically.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -62,7 +62,7 @@ Maintainers (including candidates) have:
     + a collection repository (the ``Watch`` button → ``All activity``),
     + the ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_,
     + the `Bullhorn newsletter <https://github.com/ansible/community/issues/546>`_.
-  - Knowledge and intention to manage a collection performing the tasks listed in these guidelines. Maintainers can divided responsibilities between each other.
+  - Knowledge and intention to manage a collection performing the tasks listed in these guidelines. Maintainers can divide responsibilities between each other.
 
 How to become a maintainer
 --------------------------

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -18,30 +18,41 @@ Describe how
 Communication
 =============
 
-(Maybe it's worth putting this section content
-to contributing.rst and a reference to it here?
-Because it's relevant for all contributors, not only for maintainers)
+We follow the `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_
+in all interactions within the project.
 
-Describe importance of being informed
+Be informed
+-----------
 
-Describe importance of communication in general (ref to CoC)
+Good communication is vital for prosperity of the project.
 
-Ways:
+Moreover, collection maintainers should be informed about important changes that impact all or many
+of the collections (for example, CI related) and act correspondingly to keep them up to date.
 
-  * Highly recommended:
+It is highly recommended to subscribe to the "Changes impacting collection contributors and maintainers" `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_ and the `Bullhorn newsletter <https://github.com/ansible/community/issues/546>`_.
 
-    - changes impacting collection contributors and maintainers issue
-    - Bullhorn newsletter:
+Communication channels
+----------------------
 
-      + subscription
-      +  use the issue (ref here) to announce important changes / releases of the collection
-    - contributor summits
-    - community pinboards
-    - IRC channels (#ansible-community, #ansible-devel, and dedicated ones if exist)
-  * Optional:
+Collection contributors and maintainers communicate by:
 
-    - weekly community IRC meetings
-    - mailing lists
+  * the "Changes impacting collection contributors and maintainers" `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_
+  * the Bullhorn newsletter:
+
+    + use the link in this `issue <https://github.com/ansible/community/issues/546>`_ to subscribe to the newsletter
+    + if you have something important to announce (for example, releases made recently), put a comment in the issue
+  * IRC channels such as ``#ansible-community``, ``#ansible-devel``, and specific ones
+  * Mailing lists
+  * Collection pinboards, issues, and GitHub discussions in corresponding repositories
+  * quarterly contributor summits
+  * Ansible fests and local meetups
+
+For more information about available IRC channels and mailing lists, refer to the `Ansible community documentation <https://docs.ansible.com/ansible/devel/community/communication.html>`_.
+
+Weekly community IRC meetings
+-----------------------------
+
+The important project-scale decisions are made by the community and the streeting committee at weekly IRC meetings in the ``#ansible-community`` IRC channel. If you want to see what is on the agenda, refer to issues in the `community-topics repository <https://github.com/ansible-community/community-topics>`_. If you want to submit a topic, create an issue there.
 
 Committing
 ==========

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -226,7 +226,7 @@ Be responsive. Respond as quickly as possible. Even if you cannot review a propo
 If your collection is not huge, add and keep updated the ``CONTRIBUTORS`` file listing all the contributors including issue reporters and refer to it from your ``README``. You can ask contributors to do it themselves or add a note about this to the development documentation of the collection.
 
 Do not fix trivial non-critical bugs yourself. Instead, mentor a person who would like to contribute.
-Mark issues with labels like ``easy_fix``, ``waiting_on_contributor``, ``help_wanted``, and ``documentation``.
+Mark issues with labels like ``easyfix``, ``waiting_on_contributor``, and ``docs``.
 They will let newcomers know where they can find easy wins.
 
 When reviewing an issue, if applicable, ask the author whether they want to fix the issue themselves providing the link to the `Quick-start guide <create_pr_quick_start_guide.rst>`.

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -89,7 +89,7 @@ Good communication is vital for prosperity of the project.
 
 Moreover, collection maintainers must be informed about important changes that impact all or many of the collections (for example, CI related) and act correspondingly to keep them up to date.
 
-It is required for collection maintainers to be subscribed to the ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_ and the `Bullhorn newsletter <https://github.com/ansible/community/issues/546>`_.
+It is required for collection maintainers to be subscribed to the `"Changes impacting collection contributors and maintainers" GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_ and the `Bullhorn newsletter <https://github.com/ansible/community/issues/546>`_.
 
 Communication channels
 ----------------------

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -8,7 +8,7 @@ This guide offers an overview of maintenance-related tasks, criteria for becomin
 
 The Ansible community hopes that you will find that maintaining a collection is as rewarding for you as having the collection content is for the wider community.
 
-.. contents:: Topics
+.. contents:: Topics:
 
 Collection maintainership
 =========================

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -112,7 +112,7 @@ For more information about available IRC channels and mailing lists, refer to th
 Weekly community IRC meetings
 -----------------------------
 
-The important project-scale decisions are made by the community and the streeting committee at weekly IRC meetings in the ``#ansible-community`` IRC channel. See the `meeting schedule <https://github.com/ansible/community/blob/main/meetings/README.md#schedule>`_.
+The important project-scale decisions are made by the community and the steering committee at weekly IRC meetings in the ``#ansible-community`` IRC channel. See the `meeting schedule <https://github.com/ansible/community/blob/main/meetings/README.md#schedule>`_.
 
 If you want to see what is on the agenda, refer to the issues in the `community-topics repository <https://github.com/ansible-community/community-topics>`_. If you want to submit a topic, create an issue in the repository.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -101,7 +101,7 @@ Collection contributors and maintainers communicate through:
     + use the link in this `issue <https://github.com/ansible/community/issues/546>`_ to subscribe to the newsletter
     + if you have something important to announce (for example, releases made recently), put a comment in the issue
   * IRC channels such as ``#ansible-community``, ``#ansible-devel``, and dedicated ones
-  * mailing lists
+  * mailing lists such as `ansible-announce <https://groups.google.com/d/forum/ansible-announce>`_ and `ansible-devel <https://groups.google.com/d/forum/ansible-devel>`_
   * collection pinboards, issues, and GitHub discussions in corresponding repositories
   * quarterly contributor summits
   * Ansible fests and local meetups

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -73,7 +73,7 @@ How to become a maintainer
 
 A person who is interested in becoming a maintainer and satisfies the :ref:`requirements<Requirements for maintainers>` may either self-nominate or be nominated by another maintainer.
 
-To nominate a candidate, please create a GitHub issue in the relevant collection repository repository.
+To nominate a candidate, please create a GitHub issue in the relevant collection repository. If there is no response, the repository is not actively maintained, or the current maintainers do not have permissions to add the candidate, please create the issue under `ansible/community <https://github.com/ansible/community>`_ repository.
 
 .. _Communication:
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -211,7 +211,7 @@ Maintainers are interested in increasing a number of active long-term contributo
 
 Contributors are reviewers, issue or pull request authors, testers, maintainers, and all other people who help develop the project.
 
-Every regular contributor once was a newcomer. Make the first experience as positive as possible to encourage the new people coming back.
+Every regular contributor was once a newcomer. Make the first experience as positive as possible to encourage the new people coming back.
 
 Good development documentation makes contributors life much easier. Get feedback from new contributors if there were things they struggled with when working on their proposals and improve the documentation correspondingly.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -63,7 +63,7 @@ Maintainers (including candidates) have:
   - Read these guidelines and the linked documents.
   - Subscribed to:
 
-    + the collection repository (the ``Watch`` button → ``All activity``),
+    + the collection repository they maintain (the ``Watch`` button → ``All activity``),
     + the ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_,
     + the `Bullhorn newsletter <https://github.com/ansible/community/issues/546>`_.
   - Knowledge and intention to manage a collection performing the tasks listed in these guidelines. Maintainers can divide responsibilities between each other.

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -215,7 +215,7 @@ Every regular contributor once was a newcomer. Make the first experience as posi
 
 Good development documentation makes contributors life much easier. Get feedback from new contributors if there were things they struggled with when working on their proposals and improve the documentation correspondingly.
 
-Create the ``CONTRIBUTING`` file in your repository. In there, add a link to the `Quick-start guide <create_pr_quick_start_guide.rst>` as well as to other guidelines describing things specific to your collection.
+Create the ``CONTRIBUTING`` file in your repository. In there, add a link to the `Quick-start guide <create_pr_quick_start_guide.rst>`_ as well as to other guidelines describing things specific to your collection.
 
 Make contributors feel welcome. Greet and thank contributors impersonally in ``README`` and individually in their proposals.
 Thank all participants after merging or closing a proposal.

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -249,26 +249,6 @@ In particular, they are watching that documents of the collection scope, like ``
 Reviewing
 =========
 
-[Draft] What:
-  * issues (including bug report analysis, proposal analysis)
+Maintainers can accept or reject proposed changes.
 
-    - review issues yourself first (use the review guide) as they can request
-      breaking changes, non-idempotent modules, etc
-    - ask if the author wants to implement / solve the issue themselves
-    - point to the quick start guide offering the author / other contributors
-      to implement / solve the issue
-  * PRs (proposal analysis)
-
-    - first review quickly patches yourself if they don't contain breaking changes, etc.
-    - first response is important, mention maintainers / authors / people
-      who already contributed to the code
-
-They can accept or reject the proposed features / code changes
-
-Solving
-=======
-
-[Draft] What:
-
-  * issues (contributing guidelines when merged)
-  * abandoned PRs (ask their author about difficulties, offer help, etc.)
+Maintainers review code proposals as well as reported issues following the `review checklist <review_checklist.rst>`_ in applicable parts and the recommendations mentioned in the :ref:`Expanding community <Expanding community>` paragraph.

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -157,7 +157,7 @@ Because in most cases the scope is a module or group of modules, we call these c
 The collection bot notifies module maintainers when issues / pull requests related to files they maintain are created.
 
 Module maintainers have indirect commit rights implemented through the `collection bot <https://github.com/ansible-community/collection_bot>`_.
-When two module maintainers comment with the keywords ``shipit``, ``LGTM``, or ``+1`` a pull request
+When two module maintainers comment with the keywords ``shipit``, ``LGTM``, or ``+1`` on a pull request
 which changes a module they maintain, the collection bot will merge the pull request automatically.
 
 For more information about the collection bot and its interface,

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -263,7 +263,7 @@ Documentation
 
 Maintainers look after the collection documentation.
 
-In particular, they are watching that documents of the collection scope, like ``README.md``, are relevant and timely updated and that modules / plugins documentation adhears the `Ansible documentation format <https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html>`_ and the `Style guide <https://docs.ansible.com/ansible/devel/dev_guide/style_guide/index.html#style-guide>`_.
+In particular, they are watching that documents of the collection scope, like ``README.md``, are relevant and timely updated and that modules / plugins documentation adheres the `Ansible documentation format <https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html>`_ and the `Style guide <https://docs.ansible.com/ansible/devel/dev_guide/style_guide/index.html#style-guide>`_.
 
 .. _Reviewing:
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -96,7 +96,6 @@ Communication channels
 
 Collection contributors and maintainers communicate through:
 
-  * the ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_
   * the Bullhorn newsletter:
 
     + use the link in this `issue <https://github.com/ansible/community/issues/546>`_ to subscribe to the newsletter

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -7,9 +7,13 @@ Maintaining collections
 What is the collection maintenance
 ==================================
 
-A collection is an Open Source project.
+A community of any collection can be logically divided into three major groups:
 
-If a community of any Open Source project can be logically divided into three groups: core members, contributors, and users, the collection maintainers are the core members of the collection.
+  1. Maintainers (collection owners).
+  2. Contributors.
+  3. Users.
+
+Maintainers are people who are responsible for collection maintenance.
 
 The collection maintenance consists of the regular activities listed in this document.
 
@@ -28,11 +32,12 @@ How to become a maintainer
 ==========================
 
 [DRAFT] Describe how, basically:
-1. Contribute
-2. Communicate
-3. Stay persistent
-4. Learn
-5. Submit an application (maybe an issue under https://github.com/ansible/community ?)
+
+  1. Contribute
+  2. Communicate
+  3. Stay persistent
+  4. Learn
+  5. Submit an application (maybe an issue under https://github.com/ansible/community ?)
 
 Communication
 =============
@@ -144,11 +149,12 @@ Collection maintainers release all supported stable versions of the collections 
 provided that there have been enough changes to release.
 
 Generally, releasing in the collections consists of:
-1. Planning and announcement.
-2. Generating a changelog.
-3. Creating a release git tag and pushing it.
-4. Automatic publishing the release tarball on `Ansible Galaxy <https://galaxy.ansible.com/>`_ by Zuul.
-5. Final announcement.
+
+  1. Planning and announcement.
+  2. Generating a changelog.
+  3. Creating a release git tag and pushing it.
+  4. Automatic publishing the release tarball on `Ansible Galaxy <https://galaxy.ansible.com/>`_ by Zuul.
+  5. Final announcement.
 
 For more information about the process, refer to the `Releasing guidelines <releasing.rst>`_.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -12,7 +12,7 @@ What is the collection maintenance
 
 Ansible collections community can be logically divided into four major groups:
 
-  1. Steering committee members (make desicions in scope of all the collections included in Ansible package and related areas).
+  1. Steering committee members (make decisions in scope of all the collections included in Ansible package and related areas).
   2. Maintainers.
   3. Contributors.
   4. Users.
@@ -23,7 +23,7 @@ The collection maintenance consists of the regular activities listed in these gu
 
 In particular, collection maintainers:
 
-  - :ref:`review <Reviewing>` and :ref:`commit <Commiting>` changes made by other contributors,
+  - :ref:`review <Reviewing>` and :ref:`commit <Committing>` changes made by other contributors,
   - :ref:`backport <Backporting>` changes to stable branches,
   - address issues discovered to appropriate contributors,
   - :ref:`release <Releasing>` collections,
@@ -47,7 +47,7 @@ Maintainers act in accordance with `Ansible Code of Conduct <https://docs.ansibl
 Maintainers (including candidates) have:
 
   - History of multiple contribution to a collection.
-  - Exellent technical judgement in collection-related areas.
+  - Excellent technical judgement in collection-related areas.
   - Responsiveness to mentions in issues and pull requests.
   - Responsiveness to issues and pull requests assigned to them.
   - Read these guidelines and the linked documents.
@@ -177,25 +177,60 @@ Generally, releasing in the collections consists of:
 
 For more information about the process, refer to the `Releasing guidelines <releasing.rst>`_.
 
-Expanding contributors pool
-===========================
+Expanding community
+===================
+
+Increasing a number of active contributors and maintainers
+----------------------------------------------------------
 
 Maintainers are interested in increasing a number of active long-term contributors for a collection they maintain.
 
-[Draft, rephrase] Recommendation / ways:
+Contributors are reviewers, issue or pull request authors, testers, maintainer, and all other people who help develop the project.
 
-  * Newcomer oriented. Give them first positive experience. It will make  it easy for them to keep coming back.
-  * Make people feel welcome. Welcome new people in ``README``.
-  * Labeling (``easy_fix``, ``documentation``). When people have easy wins, they will feel incentivized to do more.
-  * Leaving non-critical easy fixes to newcomers. Instead of you fixing some easy bugs, mentor a person who’d like to contribute.
-  * Be responsive. Respond as quickly as possible.
-  * Provide all relevant doc links.
-  * Adopt a zero-tolerance policy towards behavior violating `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_. How people can complain?
-  * ``README`` contains links to the `contributing.rst <contributing.rst>`_ and `Quick-start guide <create_pr_quick_start_guide.rst>`_.
-  * Creating and maintaining ``CONTRIBUTORS`` file listing all the contributors including issue reporters. Having a link from ``README`` to this file.
-  * Looking for potential maintainer among current active contributors
-  * Announcements
-  * Training
+Every regular contributor once was a newcomer. Make the first experience as positive as possible to make the new people coming back.
+
+Have good development documentation. Get feedback from new contributors if there were thing they struggled with when working on their proposals and improve the documentation correspondingly.
+
+Create the ``CONTRIBUTING`` file in your repository. In there, add a link to the `Quick-start guide <create_pr_quick_start_guide.rst>` as well as to other guidelines describing things specific to your collection.
+
+Make contributors feel welcome. Greet and thank contributors impersonally in ``README`` and individually in their proposals.
+Thank all participants after merging or closing a proposal.
+
+Be responsive. Respond as quickly as possible. Even if you cannot review a proposal right now, greet and thank the author.
+
+Add and keep updated the ``CONTRIBUTORS`` file listing all the contributors including issue reporters and refer to it from your ``README``.
+
+Do not fix trivial non-critical bugs yourself. Instead, mentor a person who would like to contribute.
+Mark issues with labels like ``easy_fix``, ``help_wanted``, and ``documentation``.
+They will let newcomers know where they can find easy wins.
+
+When reviewing an issue, if applicable, ask the author whether they want to fix the issue themselves providing the link to the `Quick-start guide <create_pr_quick_start_guide.rst>`.
+
+Adopt a zero-tolerance policy towards behavior violating `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/commun    ity/code_of_conduct.html>`_. Add information to ``README`` how people can complain.
+
+Announce that the project needs new contributors and maintainers through available communication channels.
+
+Promote active contributors satisfying :ref:`requirements <Requirements for maintainers>` to maintainers. Revise contributors activity regularly.
+
+Create the ``MAINTAINERS`` file and keep it updated.
+
+Checklist
+---------
+
+In addition to the paragraph above, here is a checklist:
+
+  * Give newcomers first positive experience.
+  * Have good documentation containing sections for newbies. 
+  * Make people feel welcome impersonally and individually.
+  * Use labels to show easy wins.
+  * Leave non-critical easy fixes to newcomers. Mentor them.
+  * Be quickly responsive.
+  * Zero-tolerance policy towards behavior violating `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/commun    ity/code_of_conduct.html>`_.
+  * Put information how people can complain in your ``README`` and ``CONTRIBUTING`` file.
+  * Links to the `contributing.rst <contributing.rst>`_ and `Quick-start guide <create_pr_quick_start_guide.rst>`, and other documentation in ``README``.
+  * Add and keep updated the ``CONTRIBUTORS`` and ``MAINTAINERS`` files.
+  * Look for new maintainers among active contributors.
+  * Announce.
 
 Documentation
 =============

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -56,7 +56,7 @@ Maintainers act in accordance with `Ansible Code of Conduct <https://docs.ansibl
 
 Maintainers (including candidates) have:
 
-  - History of multiple contribution to a collection.
+  - History of multiple contributions to a collection.
   - Excellent technical judgement in collection-related areas.
   - Responsiveness to mentions in issues and pull requests.
   - Responsiveness to issues and pull requests assigned to them.

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -194,7 +194,7 @@ Generally, releasing in the collections consists of:
   1. Planning and announcement.
   2. Generating a changelog.
   3. Creating a release git tag and pushing it.
-  4. Automatic publishing the release tarball on `Ansible Galaxy <https://galaxy.ansible.com/>`_ by Zuul.
+  4. Automatic publishing the release tarball on `Ansible Galaxy <https://galaxy.ansible.com/>`_ by `Zuul <https://dashboard.zuul.ansible.com/t/ansible/builds?pipeline=release>`_.
   5. Final announcement.
 
 For more information about the process, refer to the `Releasing guidelines <releasing.rst>`_.

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -195,6 +195,7 @@ Expanding contributors pool
   * Looking for potential maintainer among current active contributors
   * Announcements
   * Training
+  * CONTRIBUTORS file, labeling, etc.
 
 Documentation
 =============

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -231,7 +231,7 @@ They will let newcomers know where they can find easy wins.
 
 When reviewing an issue, if applicable, ask the author whether they want to fix the issue themselves providing the link to the `Quick-start guide <create_pr_quick_start_guide.rst>`.
 
-Adopt a zero-tolerance policy towards behavior violating `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_. Add information to ``README`` how people can complain.
+Adopt a zero-tolerance policy towards behavior violating `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_. Add information to ``README`` how people can complain referring to the `policy-violations Code of Conduct section<https://docs.ansible.com/ansible/latest/community/code_of_conduct.html#policy-violations>`_.
 
 Announce that the project needs new contributors and maintainers through available communication channels.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -112,7 +112,7 @@ For more information about available IRC channels and mailing lists, refer to th
 Weekly community IRC meetings
 -----------------------------
 
-The important project-scale decisions are made by the community and the steering committee at weekly IRC meetings in the ``#ansible-community`` IRC channel. See the `meeting schedule <https://github.com/ansible/community/blob/main/meetings/README.md#schedule>`_.
+The important project-scale decisions are made by the community and the Steering Committee at weekly IRC meetings in the ``#ansible-community`` IRC channel. See the `meeting schedule <https://github.com/ansible/community/blob/main/meetings/README.md#schedule>`_.
 
 If you want to see what is on the agenda, refer to the issues in the `community-topics repository <https://github.com/ansible-community/community-topics>`_. If you want to submit a topic, create an issue in the repository.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -106,7 +106,7 @@ For more information about available IRC channels and mailing lists, refer to th
 Weekly community IRC meetings
 -----------------------------
 
-The important project-scale decisions are made by the community and the streeting committee at weekly IRC meetings in the ``#ansible-community`` IRC channel. See the `meeting schedule <>https://github.com/ansible/community/blob/main/meetings/README.md#schedule>`_.
+The important project-scale decisions are made by the community and the streeting committee at weekly IRC meetings in the ``#ansible-community`` IRC channel. See the `meeting schedule <https://github.com/ansible/community/blob/main/meetings/README.md#schedule>`_.
 
 If you want to see what is on the agenda, refer to the issues in the `community-topics repository <https://github.com/ansible-community/community-topics>`_. If you want to submit a topic, create an issue in the repository.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -113,8 +113,7 @@ If you want to see what is on the agenda, refer to the issues in the `community-
 Committing
 ==========
 
-Maintainers review and merge pull requests following the `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_,
-`Review checklist <review_checklist.rst>`_, and the `Committer guidelines <https://docs.ansible.com/ansible/devel/community/committer_guidelines.html>`_.
+Maintainers review and merge pull requests following the `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_, `Review checklist <review_checklist.rst>`_, and the `Committer guidelines <https://docs.ansible.com/ansible/devel/community/committer_guidelines.html#general-rules>`_.
 
 There can be two kinds of maintainers: :ref:`collection maintainers <Collection maintainers>` and :ref:`module maintainers <Module maintainers>`.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -228,7 +228,7 @@ Do not fix trivial non-critical bugs yourself. Instead, mentor a person who woul
 Mark issues with labels like ``easyfix``, ``waiting_on_contributor``, and ``docs``.
 They will let newcomers know where they can find easy wins.
 
-When reviewing an issue, if applicable, ask the author whether they want to fix the issue themselves providing the link to the `Quick-start guide <create_pr_quick_start_guide.rst>`.
+When reviewing an issue, if applicable, ask the author whether they want to fix the issue themselves providing the link to the `Quick-start guide <create_pr_quick_start_guide.rst>`_.
 
 Adopt a zero-tolerance policy towards behavior violating `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_. Add information to ``README`` how people can complain referring to the `policy-violations Code of Conduct section<https://docs.ansible.com/ansible/latest/community/code_of_conduct.html#policy-violations>`_.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -34,7 +34,7 @@ In particular, collection maintainers:
   - :ref:`backport<Backporting>` changes to stable branches,
   - address issues discovered to appropriate contributors,
   - :ref:`release<Releasing>` collections,
-  - watch that collections adhear the `Collection Requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_,
+  - watch that collections adhere the `Collection Requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_,
   - keep tracking changes announced in ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_ and timely update a collection in accordance with them,
   - increase a number of active contributors and maintainers by :ref:`building healthy community<Expanding community>` around collections.
 

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -226,7 +226,7 @@ Be responsive. Respond as quickly as possible. Even if you cannot review a propo
 If your collection is not huge, add and keep updated the ``CONTRIBUTORS`` file listing all the contributors including issue reporters and refer to it from your ``README``. You can ask contributors to do it themselves or add a note about this to the development documentation of the collection.
 
 Do not fix trivial non-critical bugs yourself. Instead, mentor a person who would like to contribute.
-Mark issues with labels like ``easy_fix``, ``help_wanted``, and ``documentation``.
+Mark issues with labels like ``easy_fix``, ``waiting_on_contributor``, and ``documentation``.
 They will let newcomers know where they can find easy wins.
 
 When reviewing an issue, if applicable, ask the author whether they want to fix the issue themselves providing the link to the `Quick-start guide <create_pr_quick_start_guide.rst>`.

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -2,6 +2,12 @@
 Maintaining collections
 ***********************
 
+Thank you for being / your interest to become a community collection maintainer.
+
+This guide offers an overview of maintenance-related tasks, criteria for becoming a maintainer along with recommendations how to build healthy and active community around your collection.
+
+The Ansible community hopes that you will find that maintaining a collection is as rewarding for you as having the collection content is for the wider community.
+
 .. contents:: Topics
 
 Collection maintainership
@@ -111,6 +117,8 @@ Maintainers review and merge pull requests following the `Ansible Code of Conduc
 `Review checklist <review_checklist.rst>`_, and the `Committer guidelines <https://docs.ansible.com/ansible/devel/community/committer_guidelines.html>`_.
 
 There can be two kinds of maintainers: :ref:`collection maintainers <Collection maintainers>` and :ref:`module maintainers <Module maintainers>`.
+
+For the both kinds it is worth keeping in mind that “with great power comes great responsibility”.
 
 Collection maintainers
 ----------------------

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -29,12 +29,14 @@ The collection maintenance consists of the regular activities listed in these gu
 
 In particular, collection maintainers:
 
+  - keep README, development guidelines, and other general collection :ref:`documentation<Documentation>` relevant,
   - :ref:`review<Reviewing>` and :ref:`commit<Committing>` changes made by other contributors,
   - :ref:`backport<Backporting>` changes to stable branches,
   - address issues discovered to appropriate contributors,
   - :ref:`release<Releasing>` collections,
   - watch that collections adhear the `Collection Requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_,
-  - keep tracking changes announced in ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_ and timely update a collection in accordance with them.
+  - keep tracking changes announced in ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_ and timely update a collection in accordance with them,
+  - increase a number of active contributors and maintainers by :ref:`building healthy community<Expanding community>` around collections.
 
 Who is a collection maintainer
 ------------------------------
@@ -212,7 +214,7 @@ Contributors are reviewers, issue or pull request authors, testers, maintainer, 
 
 Every regular contributor once was a newcomer. Make the first experience as positive as possible to make the new people coming back.
 
-Have good development documentation. Get feedback from new contributors if there were thing they struggled with when working on their proposals and improve the documentation correspondingly.
+Good development documentation makes contributors life much easier. Get feedback from new contributors if there were things they struggled with when working on their proposals and improve the documentation correspondingly.
 
 Create the ``CONTRIBUTING`` file in your repository. In there, add a link to the `Quick-start guide <create_pr_quick_start_guide.rst>` as well as to other guidelines describing things specific to your collection.
 
@@ -229,7 +231,7 @@ They will let newcomers know where they can find easy wins.
 
 When reviewing an issue, if applicable, ask the author whether they want to fix the issue themselves providing the link to the `Quick-start guide <create_pr_quick_start_guide.rst>`.
 
-Adopt a zero-tolerance policy towards behavior violating `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/commun    ity/code_of_conduct.html>`_. Add information to ``README`` how people can complain.
+Adopt a zero-tolerance policy towards behavior violating `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_. Add information to ``README`` how people can complain.
 
 Announce that the project needs new contributors and maintainers through available communication channels.
 
@@ -245,12 +247,12 @@ Checklist
 In addition to the paragraph above, here is a checklist:
 
   * Give newcomers first positive experience.
-  * Have good documentation containing sections for newbies. 
+  * Have good documentation containing sections / guidelines for newbies. 
   * Make people feel welcome impersonally and individually.
   * Use labels to show easy wins.
   * Leave non-critical easy fixes to newcomers. Mentor them.
   * Be quickly responsive.
-  * Zero-tolerance policy towards behavior violating `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/commun    ity/code_of_conduct.html>`_.
+  * Zero-tolerance policy towards behavior violating `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_.
   * Put information how people can complain in your ``README`` and ``CONTRIBUTING`` file.
   * Links to the `contributing.rst <contributing.rst>`_ and `Quick-start guide <create_pr_quick_start_guide.rst>`, and other documentation in ``README``.
   * Add and keep updated the ``CONTRIBUTORS`` and ``MAINTAINERS`` files.

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -1,0 +1,164 @@
+***********************
+Maintaining collections
+***********************
+
+.. contents:: Topics
+
+What is maintenance and what it includes?
+
+  * point 1 (ref to the paragraph)
+  * point 2 (ref to the paragraph)
+  * point 3 (ref to the paragraph)
+
+How to become a maintainer
+==========================
+
+Describe how
+
+Communication
+=============
+
+(Maybe it's worth putting this section content
+to contributing.rst and a reference to it here?
+Because it's relevant for all contributors, not only for maintainers)
+
+Describe importance of being informed
+
+Describe importance of communication in general (ref to CoC)
+
+Ways:
+
+  * Highly recommended:
+
+    - changes impacting collection contributors and maintainers issue
+    - Bullhorn newsletter:
+
+      + subscription
+      +  use the issue (ref here) to announce important changes / releases of the collection
+    - contributor summits
+    - community pinboards
+    - IRC channels (#ansible-community, #ansible-devel, and dedicated ones if exist)
+  * Optional:
+
+    - weekly community IRC meetings
+    - mailing lists
+
+Committing
+==========
+
+Maintainers merge pull requests following the `Review checklist <review_checklist.rst>`_ and
+the `Committer guidelines <https://docs.ansible.com/ansible/devel/community/committer_guidelines.html>`_.
+
+There can be two kinds of maintainers: collection-scope maintainers and module-scope maintainers.
+
+Collection-scope maintainers
+----------------------------
+
+Collection-scope maintainers are contributors who have the ``write`` or higher access level in a collection.
+
+They have the commit right and can merge pull requests among other permissions.
+
+If applicable, the collection-scope maintainers expand a pull of module-scope maintainers.
+
+Module-scope maintainers
+------------------------
+
+This kind of maintainers exists in collections that have the `collection bot <https://github.com/ansible-community/collection_bot>`_,
+for example `community.general <https://github.com/ansible-collections/community.general>`_
+and `community.network <https://github.com/ansible-collections/community.network>`_.
+
+Module-scope maintainers are contributors who are listed in ``.github/BOTMETA.yml``.
+
+The scope can be a file (for example, a module or plugin), directory, or repository.
+
+Because in most cases the scope is a module or group of modules, we call these contributors module-scope maintainers.
+
+The collection bot notifies module-scope maintainers when issues / pull requests related to files they maintain are created.
+
+Module-scope maintainers have the indirect commit right implemented through
+the `collection bot <https://github.com/ansible-community/collection_bot>`_.
+When two module maintainers comment with the keywords ``shipit``, ``LGTM``, or ``+1`` a pull request
+which changes a module they maintain, the collection bot will merge the pull request automatically.
+
+For more information about the collection bot and its interface,
+refer to the `Collection bot overview <https://github.com/ansible-community/collection_bot/blob/main/ISSUE_HELP.md>`_.
+
+When a collection-scope maintainer considers a contribution to a file significant enough
+(it can be, for example, fixing a complex bug, adding a feature, providing regular reviews, and so on),
+they can offer the author to become a maintainer, in other words to add their GitHub login to ``.github/BOTMETA.yml``.
+
+The wording of the offer can be::
+
+  Thank you @... for the contribution!
+
+  Would you like to be added to a corresponding team in `.github/BOTMETA.yml` as a maintainer of the module?
+
+  We have a bot in this collection which is tracking the issues/pull requests including for keywords
+  such as `shipit`; the full list is [here](https://github.com/ansible-community/collection_bot/blob/main/ISSUE_HELP.md).
+
+  If your GitHub login is listed in `.github/BOTMETA.yml` as a maintainer of a module and
+  you'll put `shipit`, `LGTM`, or `+1` in a pull request that touches the module, the bot will count your `shipit`.
+  If another maintainer also puts `shipit` (so we need two), the pull request will be merged by the bot automatically.
+  So being a maintainer in `github/BOTMETA.yml` is the indirect commit privilege.
+
+  The bot also notifies module maintainers when related issues and pull requests are created.
+
+  Module-scope maintainers who are active and provide regular significant contributions (reviews and code contributions)
+  in a collection scope can be granted the `write` access to the repository.
+  In other words, they become collection-scope maintainers and can merge others' pull requests, release the collection, and so on.
+
+  We have the [review checklist](https://github.com/ansible/community-docs/blob/main/review_checklist.rst) and
+  the [contributing guidelines](https://github.com/ansible/community-docs/blob/main/contributing.rst)
+  to help maintainers on their journey.
+
+  What do you think?
+
+  Thank you!
+
+Backporting
+===========
+
+Explain, add a ref after writing a guide
+
+Nuances in c.g. / c.n
+
+=========
+Releasing
+=========
+
+(ref to releasing guidelines when merged)
+
+Expanding contributors pool
+===========================
+
+Ways to expand a contributors pool:
+
+  * Looking for potential maintainer among current active contributors
+  * Announcements
+  * ...
+
+Reviewing
+=========
+
+What:
+
+  * issues
+
+    - review issues yourself first (use the review guide) as they can request
+      breaking changes, non-idempotent modules, etc
+    - ask if the author wants to implement / solve the issue themselves
+    - point to the quick start guide offering the author / other contributors
+      to implement / solve the issue
+  * PRs
+
+    - first review quickly patches yourself if they don't contain breaking changes, etc.
+    - first response is important, mention maintainers / authors / people
+      who already contributed to the code
+
+Solving
+=======
+
+What:
+
+  * issues (contributing guidelines when merged)
+  * abandoned PRs (ask their author about difficulties, offer help, etc.)

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -59,7 +59,7 @@ Maintainers (including candidates) have:
   - Read these guidelines and the linked documents.
   - Subscribed to:
 
-    + a collection repository (the ``Watch`` button => ``All activity``),
+    + a collection repository (the ``Watch`` button → ``All activity``),
     + the ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_,
     + the `Bullhorn newsletter <https://github.com/ansible/community/issues/546>`_.
   - Knowledge and intention to manage a collection performing the tasks listed in these guidelines. Maintainers can divided responsibilities between each other.

--- a/maintaining.rst
+++ b/maintaining.rst
@@ -13,7 +13,7 @@ What is the collection maintenance
 Ansible collections community can be logically divided into four major groups:
 
   1. Steering committee members (make desicions in scope of all the collections included in Ansible package and related areas).
-  2. Maintainers (collection owners).
+  2. Maintainers.
   3. Contributors.
   4. Users.
 
@@ -21,13 +21,14 @@ Maintainers are people who are responsible for collection maintenance.
 
 The collection maintenance consists of the regular activities listed in these guidelines.
 
-In particular, collection maintainers do:
-  - :ref:`Review <Reviewing>` and :ref:`commit <Commiting>` changes made by other contributors.
-  - :ref:`Backport <Backporting>` changes to stable branches.
-  - Address issues discovered to appropriate contributors.
-  - :ref:`Release <Releasing>` collections.
-  - Watch that collections adhear the `Collection Requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_.
-  - Keep tracking changes announced in ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_ and timely update a collection in accordance with them.
+In particular, collection maintainers:
+
+  - :ref:`review <Reviewing>` and :ref:`commit <Commiting>` changes made by other contributors,
+  - :ref:`backport <Backporting>` changes to stable branches,
+  - address issues discovered to appropriate contributors,
+  - :ref:`release <Releasing>` collections,
+  - watch that collections adhear the `Collection Requirements <https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst>`_,
+  - keep tracking changes announced in ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_ and timely update a collection in accordance with them.
 
 Who is a collection maintainer
 ------------------------------
@@ -41,9 +42,10 @@ Collection maintainers satisfy the :ref:`requirements <Requirements for maintain
 Requirements for maintainers
 ----------------------------
 
+Maintainers act in accordance with `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_.
+
 Maintainers (including candidates) have:
 
-  - Acted in accordance with `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_.
   - History of multiple contribution to a collection.
   - Exellent technical judgement in collection-related areas.
   - Responsiveness to mentions in issues and pull requests.
@@ -59,20 +61,9 @@ Maintainers (including candidates) have:
 How to become a maintainer
 --------------------------
 
-[DRAFT] May either self-nominate, be nominated by another maintainer...
+A person who is interested in becoming a maintainer and satisfies the :ref:`requirements <Requirements for maintainers>` may either self-nominate or be nominated by another maintainer.
 
-[TODO] Reference to the path here (should be created first).
-
-[DRAFT] The path is basically:
-
-  1. Contribute
-  2. Communicate
-  3. Stay persistent
-  4. Learn
-  5. Submit an application (maybe an issue under https://github.com/ansible/community ?)
-  6. Become a maintainer
-  7. Participate in Ansible community IRC meetings discussing topics listed in.. Do not hesitate to share your thoughts - any opinions are much appreciated.
-  8. Become a steering committee member.
+To nominate a candidate, create and issue under the `ansible/community <https://github.com/ansible/community>`_ repository.
 
 Communication
 =============
@@ -91,14 +82,14 @@ It is required for collection maintainers to be subscribed to the ``Changes impa
 Communication channels
 ----------------------
 
-Collection contributors and maintainers communicate by:
+Collection contributors and maintainers communicate through:
 
-  * the "Changes impacting collection contributors and maintainers" `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_
+  * the ``Changes impacting collection contributors and maintainers`` `GitHub issue <https://github.com/ansible-collections/overview/issues/45>`_
   * the Bullhorn newsletter:
 
     + use the link in this `issue <https://github.com/ansible/community/issues/546>`_ to subscribe to the newsletter
     + if you have something important to announce (for example, releases made recently), put a comment in the issue
-  * IRC channels such as ``#ansible-community``, ``#ansible-devel``, and specific ones
+  * IRC channels such as ``#ansible-community``, ``#ansible-devel``, and dedicated ones
   * mailing lists
   * collection pinboards, issues, and GitHub discussions in corresponding repositories
   * quarterly contributor summits
@@ -111,13 +102,12 @@ Weekly community IRC meetings
 
 The important project-scale decisions are made by the community and the streeting committee at weekly IRC meetings in the ``#ansible-community`` IRC channel. See the `meeting schedule <>https://github.com/ansible/community/blob/main/meetings/README.md#schedule>`_.
 
-If you want to see what is on the agenda, refer to issues in the `community-topics repository <https://github.com/ansible-community/community-topics>`_. If you want to submit a topic, create an issue there.
+If you want to see what is on the agenda, refer to the issues in the `community-topics repository <https://github.com/ansible-community/community-topics>`_. If you want to submit a topic, create an issue in the repository.
 
 Committing
 ==========
 
-Maintainers review and merge pull requests following
-the `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_,
+Maintainers review and merge pull requests following the `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_,
 `Review checklist <review_checklist.rst>`_, and the `Committer guidelines <https://docs.ansible.com/ansible/devel/community/committer_guidelines.html>`_.
 
 There can be two kinds of maintainers: :ref:`collection maintainers <Collection maintainers>` and :ref:`module maintainers <Module maintainers>`.
@@ -144,12 +134,11 @@ Module maintainers are contributors who are listed in ``.github/BOTMETA.yml``.
 
 The scope can be any file (for example, a module or plugin), directory, or repository.
 
-Because in most cases the scope is a module or group of modules, we call these contributors module maintainers.
+Because in most cases the scope is a module or group of modules, we call these contributors as module maintainers.
 
 The collection bot notifies module maintainers when issues / pull requests related to files they maintain are created.
 
-Module maintainers have the indirect commit right implemented through
-the `collection bot <https://github.com/ansible-community/collection_bot>`_.
+Module maintainers have the indirect commit right implemented through the `collection bot <https://github.com/ansible-community/collection_bot>`_.
 When two module maintainers comment with the keywords ``shipit``, ``LGTM``, or ``+1`` a pull request
 which changes a module they maintain, the collection bot will merge the pull request automatically.
 
@@ -158,7 +147,7 @@ refer to the `Collection bot overview <https://github.com/ansible-community/coll
 
 When a collection maintainer considers a contribution to a file significant enough
 (it can be, for example, fixing a complex bug, adding a feature, providing regular reviews, and so on),
-they can offer the author to become a module maintainer, in other words to add their GitHub login to ``.github/BOTMETA.yml``.
+they can offer the author to become a module maintainer, in other words, to add their GitHub login to ``.github/BOTMETA.yml``.
 
 Module maintainers, as well as collection ones, act in accordance to the `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_, the `Review checklist <review_checklist.rst>`_, and the `Committer guidelines <https://docs.ansible.com/ansible/devel/community/committer_guidelines.html>`_.
 
@@ -170,13 +159,13 @@ following the `semantic versioning <https://semver.org/>`_ and release policies 
 
 For more information about the process, refer to the `Backporting guidelines <https://docs.ansible.com/ansible/devel/community/development_process.html#backporting-merged-prs-in-ansible-core>`_.
 
-Backporting can be implemented automatically using GitHub bots (for example, with the `Patchback app <https://github.com/apps/patchback>`_) and labeling like it is done in `community.general <https://github.com/ansible-collections/community.general>`_ and `community.network <https://github.com/ansible-collections/community.network>`_.
+For convenience, backporting can be implemented automatically using GitHub bots (for example, with the `Patchback app <https://github.com/apps/patchback>`_) and labeling like it is done in `community.general <https://github.com/ansible-collections/community.general>`_ and `community.network <https://github.com/ansible-collections/community.network>`_.
 
 Releasing
 =========
 
 Collection maintainers release all supported stable versions of the collections regularly,
-provided that there have been enough changes to release.
+provided that there have been enough changes merged to release.
 
 Generally, releasing in the collections consists of:
 
@@ -191,11 +180,22 @@ For more information about the process, refer to the `Releasing guidelines <rele
 Expanding contributors pool
 ===========================
 
-[Draft] Ways to expand a contributors pool:
+Maintainers are interested in increasing a number of active long-term contributors for a collection they maintain.
+
+[Draft, rephrase] Recommendation / ways:
+
+  * Newcomer oriented. Give them first positive experience. It will make  it easy for them to keep coming back.
+  * Make people feel welcome. Welcome new people in ``README``.
+  * Labeling (``easy_fix``, ``documentation``). When people have easy wins, they will feel incentivized to do more.
+  * Leaving non-critical easy fixes to newcomers. Instead of you fixing some easy bugs, mentor a person who’d like to contribute.
+  * Be responsive. Respond as quickly as possible.
+  * Provide all relevant doc links.
+  * Adopt a zero-tolerance policy towards behavior violating `Ansible Code of Conduct <https://docs.ansible.com/ansible/latest/community/code_of_conduct.html>`_. How people can complain?
+  * ``README`` contains links to the `contributing.rst <contributing.rst>`_ and `Quick-start guide <create_pr_quick_start_guide.rst>`_.
+  * Creating and maintaining ``CONTRIBUTORS`` file listing all the contributors including issue reporters. Having a link from ``README`` to this file.
   * Looking for potential maintainer among current active contributors
   * Announcements
   * Training
-  * CONTRIBUTORS file, labeling, etc.
 
 Documentation
 =============


### PR DESCRIPTION
Maintainer guidelines.

Relates to https://github.com/ansible/community-docs/pull/5 and https://github.com/ansible/community-docs/pull/2

It will include refs to contributing.rst, committer guidelines, reviewing checklist, releasing guidelines, CoC, etc.

If you have any ideas what is worth adding, welcome!

TODO: include things from https://docs.ansible.com/ansible/latest/community/maintainers.html