### PR TITLE
Add sanity test to check fragment file

### DIFF
--- a/create_pr_quick_start_guide.rst
+++ b/create_pr_quick_start_guide.rst
@@ -226,6 +226,13 @@ Click ``Create pull request``.
 
 21. Add a `changelog fragment <https://docs.ansible.com/ansible/devel/community/development_process.html#changelogs>`_ to the ``changelog/fragments`` directory. It will be published in release notes, so users will know about the fix.
 
+Run sanity test
+
+  ansible-test sanity changelog/fragments/myfragment.yml --docker -v
+
+If they failed, look at the output carefully - it is usually very informative and helps to identify a problem line quickly.
+Sanity failings usually relate to wrong documentation formatting.
+
 Commit and push it:
 
 .. code:: bash


### PR DESCRIPTION
The build server checks all files with sanity tests. 
It is easier to start the test locally and fix the problem beforehand.