### PR TITLE
Add steering_committee_past_members.rst

### DIFF
--- a/steering_committee_past_members.rst
+++ b/steering_committee_past_members.rst
@@ -1,0 +1,26 @@
+*************************************************
+Ansible Community Steering Committee Past Members
+*************************************************
+
+The Ansible Community is very grateful to these amazing **nonreplaceable**
+people for their great service to the Community and the Project!
+
+Steering Committee Past Members
+===============================
+
++------------------+-----------+-------------------+
+| Name             | GitHub    | Years of service  |
++==================+===========+===================+
+| Toshio Kuratomi  | abadger   | 2021              |
++------------------+-----------+-------------------+
+| Tadej Borovšak   | tadeboro  | 2021-2022         |
++------------------+-----------+-------------------+
+
+Steering Committee Past Chairpersons
+====================================
+
++------------------+-----------+-------------------+
+| Name             | GitHub    | Years of service  |
++==================+===========+===================+
+| Tadej Borovšak   | tadeboro  | 2021-2022         |
++------------------+-----------+-------------------+


### PR DESCRIPTION
Add steering_committee_past_members.rst to list and to credit:
- past members
- past chairpersons

IIRC this idea was originally said by @Ompragash , thank you!

If this gets merged, I:
- Add a link to this doc to ansible_community_steering_committee.rst