### PR TITLE
collection_creator_path: add a doc

### DIFF
--- a/collection_creator_path.md
+++ b/collection_creator_path.md
@@ -1,0 +1,118 @@
+### Ansible Collection Creator Path
+
+#### The guide's purpose and overview
+
+> **_NOTE:_** If you are totally unfamiliar with the collection technology, first take a look at the [Using Ansible collections guide](https://docs.ansible.com/ansible/latest/collections_guide/index.html).
+
+Ansible collections are a distribution format for Ansible content that can include playbooks, roles, modules, and plugins. You can install collections made by others or share yours with the community through a distribution server such as Ansible Galaxy.
+
+Creating and sharing collections is a great way of contribution to the Ansible project.
+
+The Ansible community package consists of `ansible-core`, which, among other core components, includes the `ansible.builtin` collection maintained by the Core team, and a set of collections maintained by the community.
+
+The purpose of this guide is to give your as a (potential) content creator a consistent overview of the Ansible collection creator journey from an idea for the first module/role to having your collection included in the Ansible community package.
+
+Each of the following guide sections will reflect one step in the path.
+
+#### Examine currently available solutions
+
+If you have an idea for a new role or module/plugin, there is no need to reinvent the wheel if there is already a sufficient solution that solve your automation issue.
+
+Therefore, first examine the currently available content on the Internet including:
+
+* [Ansible builtin modules and plugins](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/index.html)
+* [Ansible package collection index](https://docs.ansible.com/ansible/latest/collections/index.html)
+* [Ansible Galaxy](https://galaxy.ansible.com/)
+* [Ansible Automation Hub](https://www.ansible.com/products/automation-hub) if you have the Ansible Automation Platform subscription
+
+In case the solutions you found are not fully sufficient or have flaws, consider improving them rather than creating your own.
+
+If you already have your content written and used in your workflows, you could think of integrating it to the existing solutions.
+
+However, if they have significant flaws, licensing or major design issues, or their corresponding projects are unmaintained, you are encouraged to create and share your own solution.
+
+#### Create your content
+
+You [tried](#examine-currently-available-solutions) but have not found any sufficient solution for your automation issue.
+
+Use one of the following guides:
+
+* [Roles guide](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html): if you want to create a role.
+* [Developer guide](https://docs.ansible.com/ansible/latest/dev_guide/index.html): if you want to create a new Ansible module or plugin.
+
+#### Put your content in a collection
+
+You [created](#create-your-content) new content.
+
+Now it is time to create a collection to share your work with the community. Use the [Developing collections guide](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html) to learn how.
+
+We recommend you to use the [collection_template repository](https://github.com/ansible-collections/collection_template) as a basis for your collection.
+
+#### Write good user collection documentation
+
+Your collection's `README.md` file contains a quick-start installation and usage guides. You can use the [community.general collection README file](https://github.com/ansible-collections/community.general/blob/main/README.md) as an example.
+
+If your collection contains modules or plugins, make sure their documentation is comprehensive. Use the [Module format and documentation guide](https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html) and [Ansible documentation style guide](https://docs.ansible.com/ansible/latest/dev_guide/style_guide/index.html) to learn more.
+
+#### Publish your collection source code
+
+Publish your collection on a platform for software development and version control such as [GitHub](https://github.com/).
+
+It can be your personal repository or your organization's one. You can also [request](https://github.com/ansible-collections/overview/issues) a repository under the [ansible-collections](https://github.com/ansible-collections/) organization.
+
+Make sure your collection contains exhaustive license information. Ansible is an open source project, so we encourage you to license it under one of open source licenses. If you plan to submit your collection for inclusion in the Ansible community package, your collection must satisfy the [licensing requirements](https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html#collection-licensing-requirements).
+
+If you have used the [collection_template repository](https://github.com/ansible-collections/collection_template) we recommended earlier as a skeleton for your collection, it already contains the `GNU GPL v3` license.
+
+#### Follow a versioning convention
+
+When releasing new versions of your collections, take the following recommended practices into consideration:
+
+* Follow a versioning convention. Using [SemVer](https://semver.org/) is highly recommended.
+* Base your releases on [Git tags](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases).
+* If your collection repository is on GitHub, use [GitHub releases](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository).
+
+#### Understand and implement testing and CI
+
+This section is applicable to collections containing modules and plugins.
+
+If you have simple general solutions for role testing, please expand the section.
+
+##### Add tests
+
+Testing your collection ensures that your code works well and integrates with other components such as `ansible-core`.
+
+Take a look at the following documents:
+
+* [Testing Ansible guide](https://docs.ansible.com/ansible/latest/dev_guide/testing.html): provides general information about testing.
+* [Testing collections guide](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_testing.html#testing-collections): contains collection-specific testing information.
+
+##### Implement continuous integration
+
+Now make sure when pull requests are created in your collection repository they are automatically tested using a CI tool such as GitHub Actions or Azure Pipelines.
+
+The [collection_template repository](https://github.com/ansible-collections/collection_template) contains GitHub Actions [templates](https://github.com/ansible-collections/collection_template/tree/main/.github/workflows) you can adjust and use to enable the workflows in your repository.
+
+#### Provide good contributor & maintainer documentation
+
+See the [collection_template/README.md](https://github.com/ansible-collections/collection_template/blob/main/README.md) as an example.
+
+#### Publish your collection on distribution servers
+
+To distribute your collection and allow others to conveniently use it, publish your collection on one or more distribution servers. See the [Distributing collections guide](https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_distributing.html) to learn how.
+
+#### Follow the Collection requirements
+
+Make you collection satisfy the [Ansible community package collections requirements](https://docs.ansible.com/ansible/latest/community/collection_contributors/collection_requirements.html).
+
+#### Submit for inclusion
+
+After making your collection satisfy the collection requirements, you can submit it for inclusion in the Ansible community package. See the [inclusion process description](https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md) to learn how.
+
+#### Maintain
+
+Maintain your collection. See the [Ansible collection maintainer guidelines](https://docs.ansible.com/ansible/latest/community/maintainers.html) for details.
+
+#### Communication
+
+Engage with the community. Take a look at the [Ansible communication guide](https://docs.ansible.com/ansible/devel/community/communication.html) to see available communication options.

--- a/collection_creator_path.rst
+++ b/collection_creator_path.rst
@@ -1,0 +1,64 @@
+*******************************
+Ansible Collection Creator Path
+*******************************
+
+NOTE: This is a rough draft now. Please do not review the wording
+that will 100% change.
+
+The purpose of this guide is to give our collection content creators
+a consistent overview of the Ansible collection creator journey from
+an idea for the first module/role to having their collection included in
+the Ansible community package.
+
+Each paragraph will reflect one step in the path.
+
+Create your content
+===================
+
+Links to the role's guide and module/plugin dev guides are here.
+
+Also caveats about taking a look at the currently-available content
+not to reinvent the wheel.
+
+Put your content in a collection
+================================
+
+Links to the collection developer guides.
+
+Publish your collection on GitHub
+=================================
+
+TBD
+
+Understand and implement testing and CI
+=======================================
+
+Add tests
+---------
+
+TBD
+
+Implement CI
+------------
+
+GHA + AZP explained
+
+Publish your collection on Galaxy
+=================================
+
+TBD
+
+Follow the Collection requirements
+==================================
+
+Link to the requirements and a very brief explanation
+
+Submit for inclusion
+====================
+
+Links
+
+Maintain
+========
+
+Links to the Maintainer guidelines

--- a/collection_creator_path.rst
+++ b/collection_creator_path.rst
@@ -39,9 +39,10 @@ that solve your automation issue.
 
 Therefore, first examine the currently available content on the Internet including:
 
-* `Ansible Galaxy <https://galaxy.ansible.com/>`_
 * `Ansible builtin modules and plugins <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/index.html>`_
 * `Ansible package collection index <https://docs.ansible.com/ansible/latest/collections/index.html>`_
+* `Ansible Galaxy <https://galaxy.ansible.com/>`_
+* `Ansible Automation Hub <https://www.ansible.com/products/automation-hub>`_ if you have the Ansible Automation Platform subscription
 
 In case the solutions you found are not fully sufficient or have flaws,
 consider improving them rather than creating your own.
@@ -51,7 +52,7 @@ you could think of integrating it to the existing solutions.
 
 However, if they have significant flaws, licensing or major design issues,
 or their corresponding projects are unmaintained, you are encouraged
-to create and/or share your own one.
+to create and share your own solution.
 
 .. _create_content:
 
@@ -70,11 +71,10 @@ Put your content in a collection
 
 You :ref:`created <create_content>` new content.
 
-Now it is time to create a collection to share your shiny work with the community.
-
+Now it is time to create a collection to share your work with the community.
 Use the `Developing collections guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html>`_ to learn how.
 
-We recommend you to use the `collection_template repository <https://github.com/ansible-collections/collection_template>`_ as a basis.
+We recommend you to use the `collection_template repository <https://github.com/ansible-collections/collection_template>`_ as a basis for your collection.
 
 Write good user collection documentation
 ========================================
@@ -91,7 +91,7 @@ Publish your collection source code
 
 Publish your collection on a platform for software development and version control such as `GitHub <https://github.com/>`_.
 
-It can be your personal repository or your organization one.
+It can be your personal repository or your organization's one.
 You can also `request <https://github.com/ansible-collections/overview/issues>`_ a repository under the `ansible-collections <https://github.com/ansible-collections/>`_ organization.
 
 Make sure your collection contains exhaustive license information.
@@ -105,7 +105,7 @@ we recommended earlier as a skeleton for your collection, it already contains th
 Follow a versioning convention
 ==============================
 
-When releasing new versions of your collections, take the following into consideration:
+When releasing new versions of your collections, take the following recommended practices into consideration:
 
 * Follow a versioning convention. Using `SemVer <https://semver.org/>`_ is highly recommended.
 * Base your releases on `Git tags <https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases>`_.
@@ -126,7 +126,7 @@ Testing your collection ensures that your code works well and integrates with ot
 Take a look at the following documents:
 
 * `Testing Ansible guide <https://docs.ansible.com/ansible/latest/dev_guide/testing.html>`_: provides general information about testing.
-* `Testing collections guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_testing.html#testing-collections>`_: contains some collection-specific testing information.
+* `Testing collections guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_testing.html#testing-collections>`_: contains collection-specific testing information.
 
 Implement continuous integration
 --------------------------------
@@ -147,7 +147,7 @@ Publish your collection on distribution servers
 ===============================================
 
 To distribute your collection and allow others to conveniently use it,
-publish your collection on one or more distribution server.
+publish your collection on one or more distribution servers.
 See the `Distributing collections guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_distributing.html>`_ to learn how.
 
 Follow the Collection requirements

--- a/collection_creator_path.rst
+++ b/collection_creator_path.rst
@@ -2,28 +2,77 @@
 Ansible Collection Creator Path
 *******************************
 
-NOTE: This is a rough draft now. Please do not review the wording
-that will 100% change.
+The guide's purpose and overview
+================================
 
-The purpose of this guide is to give our collection content creators
+.. note::
+
+  If you are totally unfamiliar with the collection technology,
+  first take a look at the `Using Ansible collections guide <https://docs.ansible.com/ansible/latest/collections_guide/index.html>`_.
+
+Ansible collections are a distribution format for Ansible content that
+can include playbooks, roles, modules, and plugins.
+You can install collections made by others or share yours with
+the community through a distribution server such as Ansible Galaxy.
+
+Creating and sharing collections is a great way of contribution to the Ansible project.
+
+The Ansible community package consists of ``ansible-core``, which, among other core components,
+includes the ``ansible.builtin`` collection maintained by the Core team,
+and a set of collections maintained by the community.
+
+The purpose of this guide is to give your as a (potential) content creator
 a consistent overview of the Ansible collection creator journey from
-an idea for the first module/role to having their collection included in
+an idea for the first module/role to having your collection included in
 the Ansible community package.
 
-Each paragraph will reflect one step in the path.
+Each of the following guide sections will reflect one step in the path.
+
+.. _examine_existing_content:
+
+Examine currently available solutions
+=====================================
+
+If you have an idea for a new role or module/plugin,
+there is no need to reinvent the wheel if there is already a sufficient solution
+that solve your automation issue.
+
+Therefore, first examine the currently available content on the Internet including:
+
+* `Ansible Galaxy <https://galaxy.ansible.com/>`_
+* `Ansible builtin modules and plugins <https://docs.ansible.com/ansible/latest/collections/ansible/builtin/index.html>`_
+* `Ansible package collection index <https://docs.ansible.com/ansible/latest/collections/index.html>`_
+
+In case the solutions you found are not fully sufficient or have flaws,
+consider improving them rather than creating your own.
+
+If you already have your content written and used in your workflows,
+you could think of integrating it to the existing solutions.
+
+However, if they have significant flaws, licensing or major design issues,
+or their corresponding projects are unmaintained, you are encouraged
+to create and/or share your own one.
+
+.. _create_content:
 
 Create your content
 ===================
 
-Links to the role's guide and module/plugin dev guides are here.
+You :ref:`tried <examine_existing_content>` but have not found any sufficient solution for your automation issue.
 
-Also caveats about taking a look at the currently-available content
-not to reinvent the wheel.
+Use one of the following guides:
+
+* `Roles guide <https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#>`_: if you want to create a role.
+* `Developer guide <https://docs.ansible.com/ansible/latest/dev_guide/index.html>`_: if you want to create a new Ansible module or plugin.
 
 Put your content in a collection
 ================================
 
-Links to the collection developer guides.
+You :ref:`created <create_content>` new content.
+
+Now it is time to create a collection to share your shiny work with the community.
+
+Use the `Developing collections guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html>`_ to learn how.
 
 Publish your collection on GitHub
 =================================
@@ -62,3 +111,8 @@ Maintain
 ========
 
 Links to the Maintainer guidelines
+
+Communication
+=============
+
+Maybe as a separate paragraph

--- a/collection_creator_path.rst
+++ b/collection_creator_path.rst
@@ -83,7 +83,8 @@ Your collection's ``README.md`` file contains a quick-start installation and usa
 You can use the `community.general collection README file <https://github.com/ansible-collections/community.general/blob/main/README.md>`_ as an example.
 
 If your collection contains modules or plugins, make sure their documentation is comprehensive.
-Use the `Module format and documentation guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html>`_ and `Ansible documentation style guide <https://docs.ansible.com/ansible/latest/dev_guide/style_guide/index.html>`_ to learn more.
+Use the `Module format and documentation guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html>`_ and
+`Ansible documentation style guide <https://docs.ansible.com/ansible/latest/dev_guide/style_guide/index.html>`_ to learn more.
 
 Publish your collection source code
 ===================================
@@ -95,7 +96,8 @@ You can also `request <https://github.com/ansible-collections/overview/issues>`_
 
 Make sure your collection contains exhaustive license information.
 Ansible is an open source project, so we encourage you to license it under one of open source licenses.
-If you plan to submit your collection for inclusion in the Ansible community package, your collection must satisfy the `licensing requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html#collection-licensing-requirements>`_.
+If you plan to submit your collection for inclusion in the Ansible community package, your collection must satisfy
+the `licensing requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html#collection-licensing-requirements>`_.
 
 If you have used the `collection_template repository <https://github.com/ansible-collections/collection_template>`_ we recommended earlier as a skeleton for your collection, it already contains the ``GNU GPL v3`` license.
 
@@ -131,7 +133,9 @@ Implement continuous integration
 Now make sure when pull requests are created in your collection repository
 they are automatically tested using a CI tool such as GitHub Actions or Azure Pipelines.
 
-The `collection_template repository <https://github.com/ansible-collections/collection_template>`_ contains GitHub Actions `templates <https://github.com/ansible-collections/collection_template/tree/main/.github/workflows>`_ you can adjust and use to enable the workflows in your repository.
+The `collection_template repository <https://github.com/ansible-collections/collection_template>`_
+contains GitHub Actions `templates <https://github.com/ansible-collections/collection_template/tree/main/.github/workflows>`_
+you can adjust and use to enable the workflows in your repository.
 
 Provide good contributor & maintainer documentation
 ===================================================
@@ -141,7 +145,9 @@ See the `collection_template/README.md <https://github.com/ansible-collections/c
 Publish your collection on distribution servers
 ===============================================
 
-To distribute your collection and allow others to conveniently use it, publish your collection on one or more distribution server. See the `Distributing collections guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_distributing.html>`_ to learn how.
+To distribute your collection and allow others to conveniently use it,
+publish your collection on one or more distribution server.
+See the `Distributing collections guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_distributing.html>`_ to learn how.
 
 Follow the Collection requirements
 ==================================
@@ -151,14 +157,18 @@ Make you collection satisfy the `Ansible community package collections requireme
 Submit for inclusion
 ====================
 
-After making your collection satisfy the collection requirements, you can submit it for inclusion in the Ansible community package. See the `inclusion process description <https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md>`_ to learn how.
+After making your collection satisfy the collection requirements,
+you can submit it for inclusion in the Ansible community package.
+See the `inclusion process description <https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md>`_ to learn how.
 
 Maintain
 ========
 
-Maintain your collection. See the `Ansible collection maintainer guidelines <https://docs.ansible.com/ansible/latest/community/maintainers.html>`_ for details.
+Maintain your collection.
+See the `Ansible collection maintainer guidelines <https://docs.ansible.com/ansible/latest/community/maintainers.html>`_ for details.
 
 Communication
 =============
 
-Engage with the community. Take a look at the `Ansible communication guide <https://docs.ansible.com/ansible/devel/community/communication.html>`_ to see available communication options.
+Engage with the community.
+Take a look at the `Ansible communication guide <https://docs.ansible.com/ansible/devel/community/communication.html>`_ to see available communication options.

--- a/collection_creator_path.rst
+++ b/collection_creator_path.rst
@@ -74,10 +74,29 @@ Now it is time to create a collection to share your shiny work with the communit
 
 Use the `Developing collections guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_collections.html>`_ to learn how.
 
+We recommend you to use the `collection_template repository <https://github.com/ansible-collections/collection_template>`_ as a basis.
+
+Write good user collection documentation
+========================================
+
+Your collection's ``README.md`` file contains a quick-start installation and usage guides.
+You can use the `community.general collection README file <https://github.com/ansible-collections/community.general/blob/main/README.md>`_ as an example.
+
+If your collection contains modules or plugins, make sure their documentation is comprehensive. Use the `Module format and documentation guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html>`_ and `Ansible documentation style guide <https://docs.ansible.com/ansible/latest/dev_guide/style_guide/index.html>`_ to learn more.
+
 Publish your collection on GitHub
 =================================
 
-TBD
+Publish your collection on a platform for software development and version control such as `GitHub <https://github.com/>`_.
+
+It can be your personal repository or your organization one.
+You can also `request <https://github.com/ansible-collections/overview/issues>`_ a repository under the `ansible-collections <https://github.com/ansible-collections/>`_ organization.
+
+Make sure your collection contains exhaustive license information.
+Ansible is an open source project, so we encourage you to license it under one of open source licenses.
+If you plan to submit your collection for inclusion in the Ansible community package, your collection must satisfy the `licensing requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html#collection-licensing-requirements>`_.
+
+If you have used the `collection_template repository <https://github.com/ansible-collections/collection_template>`_ we recommended earlier as a skeleton for your collection, it already contains the ``GNU GPL v3`` license.
 
 Understand and implement testing and CI
 =======================================
@@ -91,6 +110,11 @@ Implement CI
 ------------
 
 GHA + AZP explained
+
+Write good contributor & maintainer documentation
+=================================================
+
+TBD
 
 Publish your collection on Galaxy
 =================================

--- a/collection_creator_path.rst
+++ b/collection_creator_path.rst
@@ -99,7 +99,8 @@ Ansible is an open source project, so we encourage you to license it under one o
 If you plan to submit your collection for inclusion in the Ansible community package, your collection must satisfy
 the `licensing requirements <https://docs.ansible.com/ansible/devel/community/collection_contributors/collection_requirements.html#collection-licensing-requirements>`_.
 
-If you have used the `collection_template repository <https://github.com/ansible-collections/collection_template>`_ we recommended earlier as a skeleton for your collection, it already contains the ``GNU GPL v3`` license.
+If you have used the `collection_template repository <https://github.com/ansible-collections/collection_template>`_
+we recommended earlier as a skeleton for your collection, it already contains the ``GNU GPL v3`` license.
 
 Follow a versioning convention
 ==============================

--- a/collection_creator_path.rst
+++ b/collection_creator_path.rst
@@ -85,8 +85,8 @@ You can use the `community.general collection README file <https://github.com/an
 If your collection contains modules or plugins, make sure their documentation is comprehensive.
 Use the `Module format and documentation guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html>`_ and `Ansible documentation style guide <https://docs.ansible.com/ansible/latest/dev_guide/style_guide/index.html>`_ to learn more.
 
-Publish your collection on GitHub
-=================================
+Publish your collection source code
+===================================
 
 Publish your collection on a platform for software development and version control such as `GitHub <https://github.com/>`_.
 
@@ -99,45 +99,66 @@ If you plan to submit your collection for inclusion in the Ansible community pac
 
 If you have used the `collection_template repository <https://github.com/ansible-collections/collection_template>`_ we recommended earlier as a skeleton for your collection, it already contains the ``GNU GPL v3`` license.
 
+Follow a versioning convention
+==============================
+
+When releasing new versions of your collections, take the following into consideration:
+
+* Follow a versioning convention. Using `SemVer <https://semver.org/>`_ is highly recommended.
+* Base your releases on `Git tags <https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases>`_.
+* If your collection repository is on GitHub, use `GitHub releases <https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository>`_.
+
 Understand and implement testing and CI
 =======================================
+
+This section is applicable to collections containing modules and plugins.
+
+If you have simple general solutions for role testing, please expand the section.
 
 Add tests
 ---------
 
-TBD
+Testing your collection ensures that your code works well and integrates with other components such as ``ansible-core``.
 
-Implement CI
-------------
+Take a look at the following documents:
 
-GHA + AZP explained
+* `Testing Ansible guide <https://docs.ansible.com/ansible/latest/dev_guide/testing.html>`_: provides general information about testing.
+* `Testing collections guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_testing.html#testing-collections>`_: contains some collection-specific testing information.
 
-Write good contributor & maintainer documentation
-=================================================
+Implement continuous integration
+--------------------------------
 
-TBD
+Now make sure when pull requests are created in your collection repository
+they are automatically tested using a CI tool such as GitHub Actions or Azure Pipelines.
 
-Publish your collection on Galaxy
-=================================
+The `collection_template repository <https://github.com/ansible-collections/collection_template>`_ contains GitHub Actions `templates <https://github.com/ansible-collections/collection_template/tree/main/.github/workflows>`_ you can adjust and use to enable the workflows in your repository.
 
-TBD
+Provide good contributor & maintainer documentation
+===================================================
+
+See the `collection_template/README.md <https://github.com/ansible-collections/collection_template/blob/main/README.md>`_ as an example.
+
+Publish your collection on distribution servers
+===============================================
+
+To distribute your collection and allow others to conveniently use it, publish your collection on one or more distribution server. See the `Distributing collections guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_distributing.html>`_ to learn how.
 
 Follow the Collection requirements
 ==================================
 
-Link to the requirements and a very brief explanation
+Make you collection satisfy the `Ansible community package collections requirements <https://docs.ansible.com/ansible/latest/community/collection_contributors/collection_requirements.html>`_.
 
 Submit for inclusion
 ====================
 
-Links
+After making your collection satisfy the collection requirements, you can submit it for inclusion in the Ansible community package. See the `inclusion process description <https://github.com/ansible-collections/ansible-inclusion/blob/main/README.md>`_ to learn how.
 
 Maintain
 ========
 
-Links to the Maintainer guidelines
+Maintain your collection. See the `Ansible collection maintainer guidelines <https://docs.ansible.com/ansible/latest/community/maintainers.html>`_ for details.
 
 Communication
 =============
 
-Maybe as a separate paragraph
+Engage with the community. Take a look at the `Ansible communication guide <https://docs.ansible.com/ansible/devel/community/communication.html>`_ to see available communication options.

--- a/collection_creator_path.rst
+++ b/collection_creator_path.rst
@@ -82,7 +82,8 @@ Write good user collection documentation
 Your collection's ``README.md`` file contains a quick-start installation and usage guides.
 You can use the `community.general collection README file <https://github.com/ansible-collections/community.general/blob/main/README.md>`_ as an example.
 
-If your collection contains modules or plugins, make sure their documentation is comprehensive. Use the `Module format and documentation guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html>`_ and `Ansible documentation style guide <https://docs.ansible.com/ansible/latest/dev_guide/style_guide/index.html>`_ to learn more.
+If your collection contains modules or plugins, make sure their documentation is comprehensive.
+Use the `Module format and documentation guide <https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html>`_ and `Ansible documentation style guide <https://docs.ansible.com/ansible/latest/dev_guide/style_guide/index.html>`_ to learn more.
 
 Publish your collection on GitHub
 =================================


### PR DESCRIPTION
We have a bunch of collection-related docs spread across docs.ansible.com
but we lack a consistent collection creator journey.

I'm afraid currently newcomers struggle with putting all the pieces together.

So the goal of this doc is to provide a consistent path that will give newcomers a good understanding of the journey and a step-by-step guidance on the "what to do with all the stuff I wrote" question.

The paragraphs will contain a brief explanation + links to related docs

The question I'd like to ask you to help me figure out are:
1. How about the idea of having this doc in general?
2. Where to put it? Options I see are:
  - docs.ansible.com, i think somewhere under https://docs.ansible.com/ansible/latest/community/contributions_collections.html 
  - maybe the forum? though, I'm inclining to docs.ansible.com as of the doc's importance
3. How about the paragraphs? My view is that each paragraph will reflect each stage of the journey. Any changes/additions?

Please help figure out;)